### PR TITLE
Register uno command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "@fuse-open/fuselibs": "~1.12.0",
     "@fuse-open/uno": "~1.12.0"
   },
+  "bin": {
+    "uno": "node_modules/.bin/uno"
+  },
   "scripts": {
     "test": "uno create app -capp -f && uno build app"
   },


### PR DESCRIPTION
After I install fuse-sdk using `npm install -g fuse-sdk` I realized that will not register `uno` command line in the path.