### PR TITLE
appveyor: use nodejs v14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,12 @@
 version: '{build}'
 image: Visual Studio 2017
 
+environment:
+  nodejs_version: 14
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+
 build_script:
   - npm install
   - npm pack


### PR DESCRIPTION
We're still using the old lock-file version so this will avoid seeing warnings in the build log.