### PR TITLE
add uno.js (beta-3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
     "axios": "^1.3.5"
   },
   "bin": {
-    "uno": "node_modules/@fuse-open/uno/bin/net6.0/uno.js"
+    "uno": "uno.js"
   },
-  "files": [],
+  "files": [
+    "uno.js"
+  ],
   "scripts": {
     "changelog": "node scripts/changelog.js",
     "prepack": "node scripts/check-dependencies.js",
-    "test": "uno build app"
+    "test": "uno build app",
+    "uno": "node uno.js"
   },
   "repository": {
     "type": "git",

--- a/uno.js
+++ b/uno.js
@@ -1,0 +1,4 @@
+const uno = require("@fuse-open/uno")
+
+uno(process.argv.slice(2))
+    .then(process.exit)


### PR DESCRIPTION
When installing fuse-sdk locally in an empty Node.js package, npm fails with an ENOENT error on some systems (MacBook Air M1 with npm v8.9.0).

This solves the problem by mapping the uno-command to a new script that dynamically loads the uno-module using the "require" function.